### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/Dynamically/Dynamically.csproj
+++ b/src/Dynamically/Dynamically.csproj
@@ -16,10 +16,18 @@
     <Description>$(Title)</Description>
     <PackageProjectUrl>https://github.com/devlooped/Dynamically</PackageProjectUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="SponsorLinker.cs" />
+  </ItemGroup>
   
   <ItemGroup>
     <EmbeddedResource Include="DynamicallyCreate.sbntxt" />
     <EmbeddedResource Include="RecordFactory.sbntxt" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="SponsorLinker.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -33,7 +41,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <!-- Scriban is included as source -->
     <PackageReference Include="Scriban" Pack="false" IncludeAssets="build" Version="5.6.0" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.6" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="0.9.6" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />-->
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.2.8" PrivateAssets="all" Pack="false" />
     <PackageReference Include="ThisAssembly.Project" Version="1.2.8" PrivateAssets="all" Pack="false" />
   </ItemGroup>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink